### PR TITLE
feat: add api utils & login apis

### DIFF
--- a/projects/common/package.json
+++ b/projects/common/package.json
@@ -20,5 +20,8 @@
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.5.1",
     "typescript": "4.5.5"
+  },
+  "dependencies": {
+    "axios": "0.26.1"
   }
 }

--- a/projects/common/src/apis/apiUtils.ts
+++ b/projects/common/src/apis/apiUtils.ts
@@ -89,16 +89,11 @@ export async function getAsync<T, D>(
   errorMessages?: Record<number, string>,
 ): ApiResult<T> {
   try {
-    const response = await axios.get<T, AxiosResponse<T, D>, D>(
-      `${apiUrl}${path}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          accept: 'application/json',
-        },
-        ...config,
-      },
-    );
+    const response = await axios.get<T, AxiosResponse<T, D>, D>(path, {
+      baseURL: apiUrl,
+      responseType: 'json',
+      ...config,
+    });
 
     return { isSuccess: true, result: response.data };
   } catch (error) {
@@ -123,17 +118,11 @@ export async function postAsync<T, D>(
   errorMessages?: Record<number, string>,
 ): ApiResult<T> {
   try {
-    const response = await axios.post<T, AxiosResponse<T, D>, D>(
-      `${apiUrl}${path}`,
-      data,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          accept: 'application/json',
-        },
-        ...config,
-      },
-    );
+    const response = await axios.post<T, AxiosResponse<T, D>, D>(path, data, {
+      baseURL: apiUrl,
+      responseType: 'json',
+      ...config,
+    });
 
     return { isSuccess: true, result: response.data };
   } catch (error) {

--- a/projects/common/src/apis/apiUtils.ts
+++ b/projects/common/src/apis/apiUtils.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { apiUrl } from 'src/constants/serverInfo';
+import { apiUrl } from '../constants/serverInfo';
 
 /*
 [[ API 타입 & 유틸 함수 ]]

--- a/projects/common/src/apis/apiUtils.ts
+++ b/projects/common/src/apis/apiUtils.ts
@@ -1,0 +1,142 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { apiUrl } from 'src/constants/serverInfo';
+
+/*
+[[ API 타입 & 유틸 함수 ]]
+*/
+
+/**
+ * API 호출 함수에서 발생하는 에러 타입
+ * @param T info의 타입
+ */
+export interface ApiError {
+  statusCode: number;
+  errorMessage: string;
+  info?: any;
+}
+
+/**
+ * API 호출 함수의 반환 타입
+ * @param T 호출에 성공하면 가져오는 데이터의 타입
+ */
+export type ApiResult<T> = Promise<
+  | {
+      isSuccess: true;
+      result: T;
+    }
+  | {
+      isSuccess: false;
+      result: ApiError;
+    }
+>;
+
+/**
+ * API 호출 함수의 에러를 받아 클라이언트의 에러 형식으로 가공하는 함수
+ * @param error 처리할 에러
+ * @param getErrorMessage status code에 따라 에러 메시지를 결정하는 함수
+ */
+function processError(
+  error: unknown,
+  errorMessages?: Record<number, string>,
+): ApiError {
+  if (axios.isAxiosError(error)) {
+    if (error.response) {
+      // 요청 전송 성공, 서버 응답 성공, 그러나 상태 코드가 2xx 이외
+      return {
+        statusCode: error.response.status,
+        errorMessage:
+          errorMessages?.[error.response.status] ??
+          '문제가 발생했어요. 다시 시도하거나 문의해 주세요.',
+        info: error.response.data,
+      };
+    }
+
+    if (error.request) {
+      // 요청 전송 성공, 그러나 서버 응답 없음
+      return {
+        statusCode: -1,
+        errorMessage:
+          '서버와 연결하지 못했어요. 인터넷 연결 상태를 확인하고 다시 시도해 주세요.',
+        info: error.request,
+      };
+    }
+  }
+
+  // 케이스 분류 실패
+  return {
+    statusCode: -1,
+    errorMessage: '문제가 발생했어요. 다시 시도하거나 문의해 주세요.',
+    info: error,
+  };
+}
+
+/*
+[[ API 호출 함수 ]]
+*/
+
+/**
+ * GET 요청을 보내는 API 호출 함수
+ * @param T 서버 응답 타입
+ * @param D parameter 또는 body로 전달할 데이터의 타입
+ *
+ * @param path API Endpoint
+ * @param config `AxiosRequestConfig`
+ * @param errorMessages status code에 따른 에러 메시지
+ */
+export async function getAsync<T, D>(
+  path: string,
+  config?: AxiosRequestConfig<D>,
+  errorMessages?: Record<number, string>,
+): ApiResult<T> {
+  try {
+    const response = await axios.get<T, AxiosResponse<T, D>, D>(
+      `${apiUrl}${path}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          accept: 'application/json',
+        },
+        ...config,
+      },
+    );
+
+    return { isSuccess: true, result: response.data };
+  } catch (error) {
+    return { isSuccess: false, result: processError(error, errorMessages) };
+  }
+}
+
+/**
+ * POST 요청을 보내는 API 호출 함수
+ * @param T 서버 응답 타입
+ * @param D parameter 또는 body로 전달할 데이터의 타입
+ *
+ * @param path API Endpoint
+ * @param data body로 전달할 데이터
+ * @param config `AxiosRequestConfig`
+ * @param errorMessages status code에 따른 에러 메시지
+ */
+export async function postAsync<T, D>(
+  path: string,
+  data?: D,
+  config?: AxiosRequestConfig<D>,
+  errorMessages?: Record<number, string>,
+): ApiResult<T> {
+  try {
+    const response = await axios.post<T, AxiosResponse<T, D>, D>(
+      `${apiUrl}${path}`,
+      data,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          accept: 'application/json',
+        },
+        ...config,
+      },
+    );
+
+    return { isSuccess: true, result: response.data };
+  } catch (error) {
+    return { isSuccess: false, result: processError(error, errorMessages) };
+  }
+}

--- a/projects/common/src/apis/auth.ts
+++ b/projects/common/src/apis/auth.ts
@@ -1,0 +1,33 @@
+import { postAsync, ApiResult } from './apiUtils';
+
+export const LOGIN_TYPE = {
+  google: 'google',
+  kakao: 'kakao',
+  appleWeb: 'apple-web',
+  appleMobile: 'apple-mobile',
+} as const;
+export type LoginType = typeof LOGIN_TYPE[keyof typeof LOGIN_TYPE];
+
+interface LoginAsyncOutput {
+  token: string;
+}
+/**
+ * 소셜 로그인 토큰으로 JWT 토큰을 받는 함수
+ * @param loginType 소셜 로그인 타입
+ * @param token 소셜 로그인으로 받은 토큰
+ */
+export async function loginAsync(
+  loginType: LoginType,
+  token: string,
+): ApiResult<LoginAsyncOutput> {
+  interface LoginAsyncInput {
+    Authorization: string;
+  }
+
+  const result = await postAsync<LoginAsyncOutput, LoginAsyncInput>(
+    `/auth/login/${loginType}`,
+    { Authorization: token },
+  );
+
+  return result;
+}

--- a/projects/common/src/apis/auth.ts
+++ b/projects/common/src/apis/auth.ts
@@ -15,6 +15,7 @@ interface LoginAsyncOutput {
  * 소셜 로그인 토큰으로 JWT 토큰을 받는 함수
  * @param loginType 소셜 로그인 타입
  * @param token 소셜 로그인으로 받은 토큰
+ * @returns `{token: JWT 토큰}`
  */
 export async function loginAsync(
   loginType: LoginType,
@@ -26,7 +27,12 @@ export async function loginAsync(
 
   const result = await postAsync<LoginAsyncOutput, LoginAsyncInput>(
     `/auth/login/${loginType}`,
-    { Authorization: token },
+    undefined,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
   );
 
   return result;

--- a/projects/common/src/apis/index.ts
+++ b/projects/common/src/apis/index.ts
@@ -1,1 +1,2 @@
 export * from './test';
+export * from './auth';

--- a/projects/common/src/apis/index.ts
+++ b/projects/common/src/apis/index.ts
@@ -1,2 +1,3 @@
 export * from './test';
 export * from './auth';
+export * from './user';

--- a/projects/common/src/apis/user.ts
+++ b/projects/common/src/apis/user.ts
@@ -1,0 +1,25 @@
+import { getAsync, ApiResult } from './apiUtils';
+import { User } from '../constants/dataTypes';
+
+type GetUserAsyncOutput = User;
+/**
+ * JWT 토큰으로 유저 정보를 받아오는 함수
+ * @param token JWT 토큰
+ * @returns `User`
+ */
+export async function getUser(token: string): ApiResult<GetUserAsyncOutput> {
+  interface GetUserAsyncInput {
+    Authorization: string;
+  }
+
+  const result = await getAsync<GetUserAsyncOutput, GetUserAsyncInput>(
+    '/user/me',
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+}

--- a/projects/common/src/constants/dataTypes.ts
+++ b/projects/common/src/constants/dataTypes.ts
@@ -1,0 +1,9 @@
+export interface User {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  email: string;
+  login_type: string;
+  nickname: string;
+  profile?: string;
+}

--- a/projects/common/src/constants/index.ts
+++ b/projects/common/src/constants/index.ts
@@ -1,1 +1,2 @@
-export * from './test'
+export * from './test';
+export * from './dataTypes';

--- a/projects/common/src/constants/serverInfo.ts
+++ b/projects/common/src/constants/serverInfo.ts
@@ -1,0 +1,1 @@
+export const apiUrl = 'https://api.sasil.app' as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4626,6 +4626,13 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios@0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -7949,6 +7956,11 @@ focus-lock@^0.10.2:
   integrity sha512-DSaI/UHZ/02sg1P616aIWgToQcrKKBmcCvomDZ1PZvcJFj350PnWhSJxJ76T3e5/GbtQEARIACtbrdlrF9C5kA==
   dependencies:
     tslib "^2.0.3"
+
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 fontfaceobserver@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Issue
#20

## Description
API 호출 기반을 마련하고, `loginAsync`와 `getUser`를 구현했습니다.
- `sasil-common`에 `axios` dependency 추가
- 공통 에러 처리 로직 도입 (`processError`)
- 모든 API 호출 함수의 반환값 통일 (`ApiResult<T>`) : `result.isSuccess`를 체크하면 `result.result`의 타입도 결정 가능
- `getAsync`, `postAsync` 추가
- `loginAsync`, `getUser` 추가

## Check List

- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
