### PR TITLE
feat: add apis for post-details and refactor types

### DIFF
--- a/projects/common/src/apis/apiUtils.ts
+++ b/projects/common/src/apis/apiUtils.ts
@@ -85,7 +85,7 @@ function processError(
  */
 export async function getAsync<T, D>(
   path: string,
-  config?: AxiosRequestConfig<D>,
+  config?: AxiosRequestConfig,
   errorMessages?: Record<number, string>,
 ): ApiResult<T> {
   try {
@@ -114,7 +114,7 @@ export async function getAsync<T, D>(
 export async function postAsync<T, D>(
   path: string,
   data?: D,
-  config?: AxiosRequestConfig<D>,
+  config?: AxiosRequestConfig,
   errorMessages?: Record<number, string>,
 ): ApiResult<T> {
   try {

--- a/projects/common/src/apis/apiUtils.ts
+++ b/projects/common/src/apis/apiUtils.ts
@@ -129,3 +129,30 @@ export async function postAsync<T, D>(
     return { isSuccess: false, result: processError(error, errorMessages) };
   }
 }
+
+/**
+ * DELETE 요청을 보내는 API 호출 함수
+ * @param T 서버 응답 타입
+ * @param D parameter 또는 body로 전달할 데이터의 타입
+ *
+ * @param path API Endpoint
+ * @param config `AxiosRequestConfig`
+ * @param errorMessages status code에 따른 에러 메시지
+ */
+export async function deleteAsync<T, D>(
+  path: string,
+  config?: AxiosRequestConfig,
+  errorMessages?: Record<number, string>,
+): ApiResult<T> {
+  try {
+    const response = await axios.delete<T, AxiosResponse<T, D>, D>(path, {
+      baseURL: apiUrl,
+      responseType: 'json',
+      ...config,
+    });
+
+    return { isSuccess: true, result: response.data };
+  } catch (error) {
+    return { isSuccess: false, result: processError(error, errorMessages) };
+  }
+}

--- a/projects/common/src/apis/auth.ts
+++ b/projects/common/src/apis/auth.ts
@@ -22,11 +22,7 @@ export async function loginAsync(
   loginType: LoginType,
   token: string,
 ): ApiResult<LoginAsyncOutput> {
-  interface LoginAsyncInput {
-    Authorization: string;
-  }
-
-  const result = await postAsync<LoginAsyncOutput, LoginAsyncInput>(
+  const result = await postAsync<LoginAsyncOutput, any>(
     `/auth/login/${loginType}`,
     undefined,
     {

--- a/projects/common/src/apis/comments.ts
+++ b/projects/common/src/apis/comments.ts
@@ -1,17 +1,103 @@
-import { WriterType } from './posts';
+import { getAsync, postAsync, deleteAsync, ApiResult } from './apiUtils';
+import { InfResultType } from './posts';
+import { WriterType } from './post';
 
-export type CommentType = {
+export interface CommentType {
   id: number;
   createdAt: Date;
   updatedAt: Date;
   content: string;
   user: WriterType;
   parentId?: number;
+}
+
+interface AddCommentAsyncInput {
+  content: string;
+}
+
+/**
+ * 게시물의 댓글 목록 조회 (최신순)
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ * @param page
+ * @param display
+ */
+export const getCommentListAsync = async (
+  postType: 'experiment' | 'request',
+  postId: number,
+  page: number,
+  display: number,
+): ApiResult<InfResultType<CommentType[]>> => {
+  const response = await getAsync<CommentType[], any>(
+    `post/${postType}/${postId}/comments`,
+    {
+      params: { page, display },
+    },
+  );
+
+  if (response.isSuccess) {
+    return {
+      isSuccess: response.isSuccess,
+      result: {
+        list: response.result,
+        nextPage: page + 1,
+        isLast: response.result.length < display,
+      },
+    };
+  }
+
+  return response;
 };
 
-export type CommentsAsyncInput = {
-  postType: 'experiment' | 'request';
-  postId: number;
-  display: number;
-  page: number;
+/**
+ * 댓글 작성
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ * @param content 댓글 내용
+ */
+export const addCommentAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+  content: string,
+): ApiResult<undefined> => {
+  const result = await postAsync<undefined, AddCommentAsyncInput>(
+    `/post/${postType}/${postId}/comment`,
+    {
+      content,
+    },
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};
+
+/**
+ * 댓글 삭제
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ * @param commentId 댓글 id값
+ */
+export const deleteCommentAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+  commentId: number,
+): ApiResult<undefined> => {
+  const result = await deleteAsync<undefined, any>(
+    `/post/${postType}/${postId}/comment/${commentId}`,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
 };

--- a/projects/common/src/apis/index.ts
+++ b/projects/common/src/apis/index.ts
@@ -4,3 +4,4 @@ export * from './user';
 export * from './posts';
 export * from './comments';
 export * from './queryKeys';
+export * from './interest';

--- a/projects/common/src/apis/index.ts
+++ b/projects/common/src/apis/index.ts
@@ -1,6 +1,7 @@
 export * from './test';
 export * from './auth';
 export * from './user';
+export * from './post';
 export * from './posts';
 export * from './comments';
 export * from './queryKeys';

--- a/projects/common/src/apis/interest.ts
+++ b/projects/common/src/apis/interest.ts
@@ -1,0 +1,95 @@
+import { postAsync, deleteAsync, ApiResult } from './apiUtils';
+
+/**
+ * 좋아요 추가
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ */
+export const addLikeAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+): ApiResult<undefined> => {
+  const result = await postAsync<undefined, any>(
+    `/post/${postType}/${postId}/like`,
+    null,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};
+
+/**
+ * 좋아요 삭제
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ */
+export const deleteLikeAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+): ApiResult<undefined> => {
+  const result = await deleteAsync<undefined, any>(
+    `/post/${postType}/${postId}/like`,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};
+
+/**
+ * 북마크 추가
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ */
+export const addBookmarkAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+): ApiResult<undefined> => {
+  const result = await postAsync<undefined, any>(
+    `/post/${postType}/${postId}/bookmark`,
+    null,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};
+
+/**
+ * 북마크 삭제
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ */
+export const deleteBookmarkAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+): ApiResult<undefined> => {
+  const result = await deleteAsync<undefined, any>(
+    `/post/${postType}/${postId}/bookmark`,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};

--- a/projects/common/src/apis/post.ts
+++ b/projects/common/src/apis/post.ts
@@ -13,7 +13,7 @@ export type CategoryType = {
   name: string;
 };
 
-export interface PostInfoType {
+export interface PostBasicType {
   id: number;
   createdAt: Date;
   updatedAt: Date;
@@ -21,21 +21,26 @@ export interface PostInfoType {
   thumbnail?: string | null;
   likeCount: number;
   user: WriterType;
-  content?: string;
-  bookmarkCount?: number;
-  isLike?: boolean;
-  isBookmark?: boolean;
-  categories?: CategoryType[];
+}
+
+export interface PostListType extends PostBasicType {
+  categories: CategoryType[];
+}
+
+export interface PostDetailType extends PostBasicType {
+  content: string;
+  bookmarkCount: number;
+  isLike: boolean;
+  isBookmark: boolean;
+  categories: CategoryType[];
   state?: Exclude<StateType, 'all'>;
 }
 
-// export interface TargetReqPostType extends PostBasicType {
-//   bookmarkCount: number;
-// }
+export interface TargetReqPostType extends PostBasicType {
+  bookmarkCount: number;
+}
 
-// export interface AnswerExpPostType extends PostBasicType {
-//   isLike: boolean;
-// }
+interface AnswerExpPostType extends PostBasicType {}
 
 interface ImgUploadURLType {
   imgUploadURL: string;
@@ -59,12 +64,15 @@ export const getPostDetailAsync = async (
   token: string,
   postType: 'experiment' | 'request',
   postId: number,
-): ApiResult<any> => {
-  const result = await getAsync<any, any>(`/post/${postType}/${postId}`, {
-    headers: {
-      Authorization: token,
+): ApiResult<PostDetailType> => {
+  const result = await getAsync<PostDetailType, any>(
+    `/post/${postType}/${postId}`,
+    {
+      headers: {
+        Authorization: token,
+      },
     },
-  });
+  );
 
   return result;
 };
@@ -73,8 +81,10 @@ export const getPostDetailAsync = async (
  * 특정 의뢰에 응답한 실험 게시물 목록 조회 (최신순)
  * @param reqId 의뢰 게시물의 id값
  */
-export const getExpListByReqAsync = async (reqId: string): ApiResult<any[]> => {
-  const result = await getAsync<any[], any>(
+export const getExpListByReqAsync = async (
+  reqId: string,
+): ApiResult<AnswerExpPostType[]> => {
+  const result = await getAsync<AnswerExpPostType[], any>(
     `/post/request/${reqId}/experiments`,
   );
 
@@ -85,8 +95,12 @@ export const getExpListByReqAsync = async (reqId: string): ApiResult<any[]> => {
  * 특정 실험 게시물이 응답한 의뢰 게시물 정보 조회
  * @param expId 실험 게시물의 id값
  */
-export const getReqPostByExpAsync = async (expId: string): ApiResult<any> => {
-  const result = await getAsync<any, any>(`/post/experiment/${expId}/request`);
+export const getReqPostByExpAsync = async (
+  expId: string,
+): ApiResult<TargetReqPostType> => {
+  const result = await getAsync<TargetReqPostType, any>(
+    `/post/experiment/${expId}/request`,
+  );
 
   return result;
 };
@@ -107,7 +121,7 @@ export const addPostAsync = async (
   title: string,
   content: string,
   thumbnail: string,
-  categories: any[],
+  categories: CategoryType[],
   reqId: number | undefined,
 ): ApiResult<undefined> => {
   const result = await postAsync<undefined, AddPostAsyncInput>(

--- a/projects/common/src/apis/post.ts
+++ b/projects/common/src/apis/post.ts
@@ -25,6 +25,7 @@ export interface PostBasicType {
 
 export interface PostListType extends PostBasicType {
   categories: CategoryType[];
+  state?: StateType;
 }
 
 export interface PostDetailType extends PostBasicType {
@@ -40,9 +41,9 @@ export interface TargetReqPostType extends PostBasicType {
   bookmarkCount: number;
 }
 
-interface AnswerExpPostType extends PostBasicType {}
+export interface AnswerExpPostType extends PostBasicType {}
 
-interface ImgUploadURLType {
+export interface ImgUploadURLType {
   imgUploadURL: string;
 }
 

--- a/projects/common/src/apis/post.ts
+++ b/projects/common/src/apis/post.ts
@@ -1,0 +1,146 @@
+import { getAsync, postAsync, ApiResult } from './apiUtils';
+
+export type StateType = 'all' | 'wait' | 'answered';
+
+export type WriterType = {
+  id: number;
+  nickname: string;
+  profileImg?: string | null;
+};
+
+export type CategoryType = {
+  id: number;
+  name: string;
+};
+
+export interface PostInfoType {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  title: string;
+  thumbnail?: string | null;
+  likeCount: number;
+  user: WriterType;
+  content?: string;
+  bookmarkCount?: number;
+  isLike?: boolean;
+  isBookmark?: boolean;
+  categories?: CategoryType[];
+  state?: Exclude<StateType, 'all'>;
+}
+
+// export interface TargetReqPostType extends PostBasicType {
+//   bookmarkCount: number;
+// }
+
+// export interface AnswerExpPostType extends PostBasicType {
+//   isLike: boolean;
+// }
+
+interface ImgUploadURLType {
+  imgUploadURL: string;
+}
+
+interface AddPostAsyncInput {
+  title: string;
+  content: string;
+  thumbnail: string;
+  categories: CategoryType[];
+  reqId?: number;
+}
+
+/**
+ * 게시물 정보 조회 (로그인 [선택])
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param postId 게시물 id값
+ */
+export const getPostDetailAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  postId: number,
+): ApiResult<any> => {
+  const result = await getAsync<any, any>(`/post/${postType}/${postId}`, {
+    headers: {
+      Authorization: token,
+    },
+  });
+
+  return result;
+};
+
+/**
+ * 특정 의뢰에 응답한 실험 게시물 목록 조회 (최신순)
+ * @param reqId 의뢰 게시물의 id값
+ */
+export const getExpListByReqAsync = async (reqId: string): ApiResult<any[]> => {
+  const result = await getAsync<any[], any>(
+    `/post/request/${reqId}/experiments`,
+  );
+
+  return result;
+};
+
+/**
+ * 특정 실험 게시물이 응답한 의뢰 게시물 정보 조회
+ * @param expId 실험 게시물의 id값
+ */
+export const getReqPostByExpAsync = async (expId: string): ApiResult<any> => {
+  const result = await getAsync<any, any>(`/post/experiment/${expId}/request`);
+
+  return result;
+};
+
+/**
+ * 게시물 작성
+ * @param token 소셜 로그인으로 받은 토큰
+ * @param postType 게시물 타입
+ * @param title 게시물 제목
+ * @param content 게시물 내용
+ * @param thumbnail 게시물 썸네일
+ * @param categories 게시물 카테고리 목록
+ * @param reqId 실험 게시물인 경우, 수행한 의뢰 게시물 id값
+ */
+export const addPostAsync = async (
+  token: string,
+  postType: 'experiment' | 'request',
+  title: string,
+  content: string,
+  thumbnail: string,
+  categories: any[],
+  reqId: number | undefined,
+): ApiResult<undefined> => {
+  const result = await postAsync<undefined, AddPostAsyncInput>(
+    `/post/${postType}`,
+    {
+      title,
+      content,
+      thumbnail,
+      categories,
+      reqId,
+    },
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return result;
+};
+
+/**
+ * 이미지 업로드 URL
+ * @param token 소셜 로그인으로 받은 토큰
+ */
+export const getImgUploadURLAsync = async (
+  token: string,
+): ApiResult<ImgUploadURLType> => {
+  const result = await getAsync<ImgUploadURLType, any>(`/post/image`, {
+    headers: {
+      Authorization: token,
+    },
+  });
+
+  return result;
+};

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -1,5 +1,5 @@
 import { getAsync, ApiResult } from './apiUtils';
-import { StateType, PostInfoType } from './post';
+import { StateType, PostListType } from './post';
 
 export type SortType = 'recent' | 'popular';
 
@@ -24,8 +24,8 @@ export const getPostsAsync = async (
   display: number,
   sort: SortType,
   state?: StateType,
-): ApiResult<InfResultType<any[]>> => {
-  const response = await getAsync<any[], any>(`/posts/${type}`, {
+): ApiResult<InfResultType<PostListType[]>> => {
+  const response = await getAsync<PostListType[], any>(`/posts/${type}`, {
     params: { page, display, sort, state },
   });
 

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -1,34 +1,7 @@
 import { getAsync, ApiResult } from './apiUtils';
+import { StateType, PostInfoType } from './post';
 
 export type SortType = 'recent' | 'popular';
-export type StateType = 'all' | 'wait' | 'answered';
-
-export type WriterType = {
-  id: number;
-  nickname: string;
-  profileImg?: string | null;
-};
-
-export type CategoryType = {
-  id: number;
-  name: string;
-};
-
-export interface PostInfoType {
-  id: number;
-  createdAt: Date;
-  updatedAt: Date;
-  title: string;
-  content?: string;
-  thumbnail?: string | null;
-  likeCount: number;
-  bookmarkCount: number;
-  isLike?: boolean;
-  isBookmark?: boolean;
-  user: WriterType;
-  categories?: CategoryType[];
-  state?: Exclude<StateType, 'all'>;
-}
 
 export type InfResultType<T> = {
   list: T;
@@ -51,8 +24,8 @@ export const getPostsAsync = async (
   display: number,
   sort: SortType,
   state?: StateType,
-): ApiResult<InfResultType<PostInfoType[]>> => {
-  const response = await getAsync<PostInfoType[], any>(`/posts/${type}`, {
+): ApiResult<InfResultType<any[]>> => {
+  const response = await getAsync<any[], any>(`/posts/${type}`, {
     params: { page, display, sort, state },
   });
 

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -36,13 +36,6 @@ export type ResultType<T> = {
   isLast: boolean;
 };
 
-export interface PostsAsyncInput {
-  display: number;
-  page: number;
-  sort: SortType;
-  state?: StateType;
-}
-
 /**
  * 기준에 따른 게시물 목록 반환하는 함수
  *
@@ -59,12 +52,9 @@ export const getPostsAsync = async (
   sort: SortType,
   state?: StateType,
 ): ApiResult<ResultType<PostInfoType[]>> => {
-  const response = await getAsync<PostInfoType[], PostsAsyncInput>(
-    `/posts/${type}`,
-    {
-      params: { page, display, sort, state },
-    },
-  );
+  const response = await getAsync<PostInfoType[], any>(`/posts/${type}`, {
+    params: { page, display, sort, state },
+  });
 
   if (response.isSuccess) {
     return {

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -30,8 +30,8 @@ export interface PostInfoType {
   state?: Exclude<StateType, 'all'>;
 }
 
-export type ResultType<T> = {
-  posts: T;
+export type InfResultType<T> = {
+  list: T;
   nextPage: number;
   isLast: boolean;
 };
@@ -51,7 +51,7 @@ export const getPostsAsync = async (
   display: number,
   sort: SortType,
   state?: StateType,
-): ApiResult<ResultType<PostInfoType[]>> => {
+): ApiResult<InfResultType<PostInfoType[]>> => {
   const response = await getAsync<PostInfoType[], any>(`/posts/${type}`, {
     params: { page, display, sort, state },
   });
@@ -60,7 +60,7 @@ export const getPostsAsync = async (
     return {
       isSuccess: response.isSuccess,
       result: {
-        posts: response.result,
+        list: response.result,
         nextPage: page + 1,
         isLast: response.result.length < display,
       },

--- a/projects/common/src/hooks/useListQuery.ts
+++ b/projects/common/src/hooks/useListQuery.ts
@@ -1,6 +1,10 @@
 import { useInfiniteQuery } from 'react-query';
-import { PostListType } from '@sasil/common';
-import { getPostsAsync, QUERY_KEYS, InfResultType } from '../apis';
+import {
+  getPostsAsync,
+  QUERY_KEYS,
+  InfResultType,
+  PostListType,
+} from '../apis';
 import { ApiResult } from '../apis/apiUtils';
 
 interface PostsAsyncInput {

--- a/projects/common/src/hooks/useListQuery.ts
+++ b/projects/common/src/hooks/useListQuery.ts
@@ -1,4 +1,5 @@
 import { useInfiniteQuery } from 'react-query';
+import { PostListType } from '@sasil/common';
 import { getPostsAsync, QUERY_KEYS, InfResultType } from '../apis';
 import { ApiResult } from '../apis/apiUtils';
 
@@ -26,14 +27,14 @@ export const LIST_API = {
       getResult(await getPostsAsync('request', page, display, sort, state)),
     queryKey: QUERY_KEYS.requests,
     paramType: {} as Omit<PostsAsyncInput, 'page'>,
-    resultType: {} as InfResultType<any[]>,
+    resultType: {} as InfResultType<PostListType[]>,
   },
   getExperiments: {
     fetcher: async ({ page, display, sort }: Omit<PostsAsyncInput, 'state'>) =>
       getResult(await getPostsAsync('experiment', page, display, sort)),
     queryKey: QUERY_KEYS.experiments,
     paramType: {} as Omit<PostsAsyncInput, 'page' | 'state'>,
-    resultType: {} as InfResultType<any[]>,
+    resultType: {} as InfResultType<PostListType[]>,
   },
 } as const;
 

--- a/projects/common/src/hooks/useListQuery.ts
+++ b/projects/common/src/hooks/useListQuery.ts
@@ -1,12 +1,13 @@
 import { useInfiniteQuery } from 'react-query';
-import {
-  getPostsAsync,
-  PostsAsyncInput,
-  QUERY_KEYS,
-  ResultType,
-  PostInfoType,
-} from '../apis';
+import { getPostsAsync, QUERY_KEYS, InfResultType } from '../apis';
 import { ApiResult } from '../apis/apiUtils';
+
+interface PostsAsyncInput {
+  page: number;
+  display: number;
+  sort: 'recent' | 'popular';
+  state?: 'all' | 'answered' | 'wait';
+}
 
 function getResult<T>(response: Awaited<ApiResult<T>>) {
   if (response.isSuccess) {
@@ -25,14 +26,14 @@ export const LIST_API = {
       getResult(await getPostsAsync('request', page, display, sort, state)),
     queryKey: QUERY_KEYS.requests,
     paramType: {} as Omit<PostsAsyncInput, 'page'>,
-    resultType: {} as ResultType<PostInfoType[]>,
+    resultType: {} as InfResultType<any[]>,
   },
   getExperiments: {
     fetcher: async ({ page, display, sort }: Omit<PostsAsyncInput, 'state'>) =>
       getResult(await getPostsAsync('experiment', page, display, sort)),
     queryKey: QUERY_KEYS.experiments,
     paramType: {} as Omit<PostsAsyncInput, 'page' | 'state'>,
-    resultType: {} as ResultType<PostInfoType[]>,
+    resultType: {} as InfResultType<any[]>,
   },
 } as const;
 

--- a/projects/sasil-mobile/src/components/dummyData.ts
+++ b/projects/sasil-mobile/src/components/dummyData.ts
@@ -1,4 +1,4 @@
-import { CategoryType, PostInfoType } from '@sasil/common';
+import { CategoryType, PostListType } from '@sasil/common';
 
 export const users = [
   {
@@ -14,7 +14,7 @@ export const users = [
   },
 ];
 
-export const expPosts: PostInfoType[] = [
+export const expPosts: PostListType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
@@ -25,7 +25,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 2,
@@ -37,7 +36,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 3,
@@ -48,7 +46,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 4,
@@ -59,7 +56,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 5,
@@ -71,7 +67,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 6,
@@ -82,7 +77,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 7,
@@ -94,7 +88,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 8,
@@ -106,7 +99,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 9,
@@ -118,7 +110,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 10,
@@ -130,7 +121,6 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 11,
@@ -141,11 +131,10 @@ export const expPosts: PostInfoType[] = [
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
 ];
 
-export const reqPosts: PostInfoType[] = [
+export const reqPosts: PostListType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
@@ -157,7 +146,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 2,
@@ -170,7 +158,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 3,
@@ -183,7 +170,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 4,
@@ -196,7 +182,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 5,
@@ -209,7 +194,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 6,
@@ -222,7 +206,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 7,
@@ -235,7 +218,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 8,
@@ -248,7 +230,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 9,
@@ -261,7 +242,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 10,
@@ -274,7 +254,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 11,
@@ -287,7 +266,6 @@ export const reqPosts: PostInfoType[] = [
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
 ];
 

--- a/projects/sasil-mobile/src/components/templates/MainTemplate/MainTemplate.tsx
+++ b/projects/sasil-mobile/src/components/templates/MainTemplate/MainTemplate.tsx
@@ -1,4 +1,4 @@
-import { COLORS, PostInfoType, TEXT_STYLE_NAME } from '@sasil/common';
+import { COLORS, PostListType, TEXT_STYLE_NAME } from '@sasil/common';
 
 import SasilLogo from '@/assets/icons/SasilLogo';
 import SearchIcon from '@/assets/icons/Search';
@@ -11,12 +11,11 @@ import {
   MainPostsWrap,
   postsTitleType,
 } from '@/components/templates/PostsWrap';
-import NavBar from '@/components/templates/NavBar';
 import * as styles from './MainTemplate.style';
 
 interface ContentProps {
   type: postsTitleType;
-  posts: PostInfoType[];
+  posts: PostListType[];
 }
 
 const Content = ({ type, posts }: ContentProps) => (
@@ -48,9 +47,9 @@ const Content = ({ type, posts }: ContentProps) => (
 
 interface MainTemplateProps {
   // TODO post type 지정
-  hotReqPosts: PostInfoType[];
-  popReqPosts: PostInfoType[];
-  popExpPosts: PostInfoType[];
+  hotReqPosts: PostListType[];
+  popReqPosts: PostListType[];
+  popExpPosts: PostListType[];
 }
 
 // TODO 페이지 구현하면 NavBar 연결

--- a/projects/sasil-mobile/src/components/templates/PostsWrap/MainPostsWrap.tsx
+++ b/projects/sasil-mobile/src/components/templates/PostsWrap/MainPostsWrap.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { PostInfoType } from '@sasil/common';
+import { PostListType } from '@sasil/common';
 import PostCard from '@/components/organisms/PostCard';
 import PostsWrapTitle, { POSTS_INFO, postsTitleType } from './MainPostsNavCard';
 import * as styles from './MainPostsWrap.style';
 
 export interface MainPostsWrapProps {
-  posts: PostInfoType[];
+  posts: PostListType[];
   type: postsTitleType;
 }
 
 const MainPostsWrap = ({ posts, type }: MainPostsWrapProps) => (
   <styles.Wrap>
-    {posts.map((post: PostInfoType, index: number) => (
+    {posts.map((post: PostListType, index: number) => (
       <React.Fragment key={post.id}>
         {index === POSTS_INFO[type].index && (
           <PostsWrapTitle type={type} style={styles.item} />

--- a/projects/sasil-mobile/src/components/templates/PostsWrap/PostsWrap.tsx
+++ b/projects/sasil-mobile/src/components/templates/PostsWrap/PostsWrap.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback } from 'react';
 import { FlatList, ListRenderItemInfo } from 'react-native';
-import { PostInfoType } from '@sasil/common';
+import { PostListType } from '@sasil/common';
 
 import PostCard from '@/components/organisms/PostCard';
 import * as styles from './PostsWrap.style';
 
 export interface PostsWrapProps {
-  posts: PostInfoType[];
+  posts: PostListType[];
   type: 'request' | 'experiment';
   fetchNextPage?: () => Promise<void>;
   onRefresh?: () => Promise<void>;
@@ -21,7 +21,7 @@ const PostsWrap = ({
   isRefreshing,
 }: PostsWrapProps) => {
   const renderItem = useCallback(
-    ({ item }: ListRenderItemInfo<PostInfoType>) => (
+    ({ item }: ListRenderItemInfo<PostListType>) => (
       <PostCard
         type={type}
         title={item.title}
@@ -39,7 +39,7 @@ const PostsWrap = ({
     await fetchNextPage?.();
   }, [fetchNextPage]);
 
-  const keyExtractor = useCallback((item: PostInfoType) => `${item.id}`, []);
+  const keyExtractor = useCallback((item: PostListType) => `${item.id}`, []);
 
   return (
     <FlatList

--- a/projects/sasil-mobile/src/screens/ExperimentScreen/ExperimentScreen.tsx
+++ b/projects/sasil-mobile/src/screens/ExperimentScreen/ExperimentScreen.tsx
@@ -26,7 +26,7 @@ const RequestScreen = () => {
   }, [refetch]);
 
   const posts = useMemo(
-    () => data?.pages.map((page) => page.posts).flat(),
+    () => data?.pages.map((page) => page.list).flat(),
     [data],
   );
 

--- a/projects/sasil-mobile/src/screens/MainScreen/MainScreen.tsx
+++ b/projects/sasil-mobile/src/screens/MainScreen/MainScreen.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
-import { getPostsAsync, PostInfoType } from '@sasil/common';
+import { getPostsAsync, PostListType } from '@sasil/common';
 import { expPosts, reqPosts } from '@/components/dummyData';
 import MainTemplate from '@/components/templates/MainTemplate';
 import * as styles from './MainScreen.style';
 
 const MainScreen = () => {
   const [posts, setPosts] = useState<{
-    hotReqPosts: PostInfoType[];
-    popExpPosts: PostInfoType[];
-    popReqPosts: PostInfoType[];
+    hotReqPosts: PostListType[];
+    popExpPosts: PostListType[];
+    popReqPosts: PostListType[];
   }>({
     hotReqPosts: [],
     popExpPosts: [],
@@ -24,9 +24,9 @@ const MainScreen = () => {
       ]);
 
       setPosts({
-        hotReqPosts: hotReq.isSuccess ? hotReq.result.posts : [],
-        popExpPosts: popExp.isSuccess ? popExp.result.posts : [],
-        popReqPosts: popReq.isSuccess ? popReq.result.posts : [],
+        hotReqPosts: hotReq.isSuccess ? hotReq.result.list : [],
+        popExpPosts: popExp.isSuccess ? popExp.result.list : [],
+        popReqPosts: popReq.isSuccess ? popReq.result.list : [],
       });
     }
 

--- a/projects/sasil-mobile/src/screens/RequestScreen/RequestScreen.tsx
+++ b/projects/sasil-mobile/src/screens/RequestScreen/RequestScreen.tsx
@@ -27,7 +27,7 @@ const RequestScreen = () => {
   }, [refetch]);
 
   const posts = useMemo(
-    () => data?.pages.map((page) => page.posts).flat(),
+    () => data?.pages.map((page) => page.list).flat(),
     [data],
   );
 

--- a/projects/sasil-web/src/components/templates/MainTemplate/MainTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/MainTemplate/MainTemplate.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 
-import { COLORS, PostInfoType, TEXT_STYLE_NAME } from '@sasil/common';
+import { COLORS, PostListType, TEXT_STYLE_NAME } from '@sasil/common';
 import { URL_INFO } from '@/constants/urlInfo';
 import RightIcon from '@/assets/icons/Right.svg';
 import { POSTS_INFO } from '@/components/templates/PostsWrap/MainPostsNavCard';
@@ -36,9 +36,9 @@ const ViewMoreButton = ({ type }: ViewMoreButtonProp) => {
 };
 
 interface MainTemplateProps {
-  hotReqPosts: PostInfoType[];
-  popReqPosts: PostInfoType[];
-  popExpPosts: PostInfoType[];
+  hotReqPosts: PostListType[];
+  popReqPosts: PostListType[];
+  popExpPosts: PostListType[];
 }
 
 const MainTemplate = ({

--- a/projects/sasil-web/src/components/templates/PostSummary/PostSummary.tsx
+++ b/projects/sasil-web/src/components/templates/PostSummary/PostSummary.tsx
@@ -1,7 +1,11 @@
 import StyledButton from '@/components/atoms/StyledButton';
 import * as Post from '@/components/organisms/post';
 import PostInfoCard from '@/components/organisms/PostInfoCard';
-import { PostInfoType } from '@sasil/common';
+import {
+  AnswerExpPostType,
+  TargetReqPostType,
+  PostDetailType,
+} from '@sasil/common';
 import { useRouter } from 'next/router';
 import * as styles from './PostSummary.style';
 
@@ -9,9 +13,9 @@ export interface PostSummaryProps {
   /** 게시물의 종류로, 의뢰 혹은 실험 중 하나. */
   type: 'request' | 'experiment';
   /** 게시물 객체 */
-  post: PostInfoType;
+  post: PostDetailType;
   /** 게시물 type이 실험이라면 해당 게시물이 응답한 의뢰 게시물. 의뢰라면 해당 게시물에 응답한 실험 게시물 리스트. */
-  relativePosts: PostInfoType[];
+  relativePosts: AnswerExpPostType[];
 }
 
 /** 게시물 상세 페이지 사이드에 띄워지는 게시물 요약 컴포넌트 */

--- a/projects/sasil-web/src/components/templates/PostsWrap/MainPostsWrap.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/MainPostsWrap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PostInfoType } from '@sasil/common';
+import { PostListType } from '@sasil/common';
 import * as Post from '@/components/organisms/post';
 import MainPostsNavCard, {
   POSTS_INFO,
@@ -11,7 +11,7 @@ import * as styles from './MainPostsWrap.styles';
 export interface MainPostsWrapProps {
   // TODO posts는 불러올 때 11개만 가져와야함!
   /**  게시물 데이터 */
-  posts?: PostInfoType[];
+  posts?: PostListType[];
   /** 메인에서 노출되는 게시물 종류(답변 안달린 핫한 의뢰, 인기 의뢰, 인기 실험 중 하나) */
   type: postsTitleType;
   className?: string;

--- a/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
@@ -1,17 +1,17 @@
 import React, { forwardRef } from 'react';
 
 import { Card } from '@/components/organisms/post';
-import { PostInfoType } from '@sasil/common';
+import { PostListType } from '@sasil/common';
 import * as styles from './PostsWrap.style';
 
 export interface PostsWrapProps {
-  posts: PostInfoType[] | undefined;
+  posts: PostListType[] | undefined;
 }
 
 const PostsWrap = forwardRef<HTMLDivElement, PostsWrapProps>(
   ({ posts }, ref) => (
     <styles.Container ref={ref}>
-      {posts?.map((post: any) => (
+      {posts?.map((post: PostListType) => (
         <Card
           key={post.id}
           title={post.title}

--- a/projects/sasil-web/src/dummyData.ts
+++ b/projects/sasil-web/src/dummyData.ts
@@ -1,4 +1,11 @@
-import { CategoryType, CommentType, PostInfoType } from '@sasil/common';
+import {
+  CategoryType,
+  CommentType,
+  PostDetailType,
+  PostListType,
+  TargetReqPostType,
+  AnswerExpPostType,
+} from '@sasil/common';
 
 export const users = [
   {
@@ -14,246 +21,210 @@ export const users = [
   },
 ];
 
-export const expPosts: PostInfoType[] = [
+export const expPosts: PostListType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost1',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 2,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost2',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 3,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost3',
-    content: '실험 본문',
     thumbnail: null,
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 4,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail: null,
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 5,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 6,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail: null,
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 7,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 8,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 9,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 10,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
   {
     id: 11,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail: null,
     user: users[0],
     categories: [],
     likeCount: 9,
-    bookmarkCount: 25,
   },
 ];
 
-export const reqPosts: PostInfoType[] = [
+export const reqPosts: PostListType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost1',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 2,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 3,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 4,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 5,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 6,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 7,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
     title: 'testPost',
-    content: '실험 본문',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 8,
@@ -264,10 +235,8 @@ export const reqPosts: PostInfoType[] = [
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
-    content: '실험 본문',
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 9,
@@ -278,10 +247,8 @@ export const reqPosts: PostInfoType[] = [
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
-    content: '실험 본문',
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 10,
@@ -292,10 +259,8 @@ export const reqPosts: PostInfoType[] = [
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
-    content: '실험 본문',
     state: 'answered',
     likeCount: 25,
-    bookmarkCount: 25,
   },
   {
     id: 11,
@@ -306,10 +271,8 @@ export const reqPosts: PostInfoType[] = [
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
     categories: [],
-    content: '실험 본문',
     state: 'wait',
     likeCount: 25,
-    bookmarkCount: 25,
   },
 ];
 
@@ -323,7 +286,7 @@ export const categories: CategoryType[] = [
   { id: 7, name: 'Storybook' },
 ];
 
-export const reqPostDetail = {
+export const reqPostDetail: PostDetailType = {
   id: 9,
   createdAt: new Date('2022-05-19T14:53:43.044Z'),
   updatedAt: new Date('2022-05-19T14:53:43.044Z'),
@@ -344,7 +307,7 @@ export const reqPostDetail = {
   ],
 };
 
-export const reqAnswerPosts: PostInfoType[] = [
+export const reqAnswerPosts: AnswerExpPostType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
@@ -353,10 +316,7 @@ export const reqAnswerPosts: PostInfoType[] = [
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
-    categories: [],
-    state: 'answered',
     likeCount: 25,
-    bookmarkCount: 9,
   },
   {
     id: 2,
@@ -366,10 +326,7 @@ export const reqAnswerPosts: PostInfoType[] = [
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
-    categories: [],
-    state: 'wait',
     likeCount: 25,
-    bookmarkCount: 9,
   },
   {
     id: 3,
@@ -379,10 +336,7 @@ export const reqAnswerPosts: PostInfoType[] = [
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
-    categories: [],
-    state: 'wait',
     likeCount: 25,
-    bookmarkCount: 9,
   },
   {
     id: 4,
@@ -392,14 +346,11 @@ export const reqAnswerPosts: PostInfoType[] = [
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',
     user: users[1],
-    categories: [],
-    state: 'wait',
     likeCount: 25,
-    bookmarkCount: 9,
   },
 ];
 
-export const expPostDetail: PostInfoType = {
+export const expPostDetail: PostDetailType = {
   id: 9,
   createdAt: new Date('2022-05-19T14:53:43.044Z'),
   updatedAt: new Date('2022-05-19T14:53:43.044Z'),
@@ -451,12 +402,11 @@ export const comments: CommentType[] = [
     content: '안녕하세요  댓글이에요 4',
   },
 ];
-export const expRequestPost: PostInfoType[] = [
+export const expRequestPost: TargetReqPostType[] = [
   {
     id: 1,
     createdAt: new Date('2022-05-19T14:53:43.044Z'),
     updatedAt: new Date('2022-05-19T14:53:43.044Z'),
-    content: '실험이 응답한 의뢰 게시물',
     title: 'testPost1',
     thumbnail:
       'https://image.shutterstock.com/image-photo/cute-labrador-dog-playing-stick-600w-1935251336.jpg',

--- a/projects/sasil-web/src/pages/experiment.tsx
+++ b/projects/sasil-web/src/pages/experiment.tsx
@@ -42,7 +42,7 @@ const ExperimentPage: NextPage = () => {
   useInifiniteScroll(postsRef, getExpPosts);
 
   const postsData = data?.pages
-    .map((res) => (res.isSuccess ? res.result.posts : []))
+    .map((res) => (res.isSuccess ? res.result.list : []))
     .flat();
 
   return (

--- a/projects/sasil-web/src/pages/index.tsx
+++ b/projects/sasil-web/src/pages/index.tsx
@@ -1,12 +1,12 @@
 import Head from 'next/head';
-import { getPostsAsync, PostInfoType } from '@sasil/common';
+import { getPostsAsync, PostListType } from '@sasil/common';
 import MainTemplate from '@/components/templates/MainTemplate';
 import { expPosts, reqPosts } from 'src/dummyData';
 
 interface MainPageProps {
-  hotReqPosts: PostInfoType[];
-  popReqPosts: PostInfoType[];
-  popExpPosts: PostInfoType[];
+  hotReqPosts: PostListType[];
+  popReqPosts: PostListType[];
+  popExpPosts: PostListType[];
 }
 
 export async function getServerSideProps() {
@@ -17,9 +17,9 @@ export async function getServerSideProps() {
   ]);
 
   const result: MainPageProps = {
-    hotReqPosts: hotReq.isSuccess ? hotReq.result.posts : [],
-    popReqPosts: popReq.isSuccess ? popReq.result.posts : [],
-    popExpPosts: popExp.isSuccess ? popExp.result.posts : [],
+    hotReqPosts: hotReq.isSuccess ? hotReq.result.list : [],
+    popReqPosts: popReq.isSuccess ? popReq.result.list : [],
+    popExpPosts: popExp.isSuccess ? popExp.result.list : [],
   };
 
   return { props: result };

--- a/projects/sasil-web/src/pages/request.tsx
+++ b/projects/sasil-web/src/pages/request.tsx
@@ -43,7 +43,7 @@ const RequestPage: NextPage = () => {
   useInifiniteScroll(postsRef, getReqPosts);
 
   const postsData = data?.pages
-    .map((res) => (res.isSuccess ? res.result.posts : []))
+    .map((res) => (res.isSuccess ? res.result.list : []))
     .flat();
 
   return (


### PR DESCRIPTION
## Issue
#54 

## Description
- 게시물 상세 페이지를 위한 common에 API 함수 추가
  (백엔드에서 게시물 작성까지 완료된 상태이므로 해당 API 함수까지 추가)
- 잘못된 타입과 관련 코드들까지 모두 수정

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
