### PR TITLE
feat: add search logic in web

### DIFF
--- a/projects/common/src/apis/index.ts
+++ b/projects/common/src/apis/index.ts
@@ -6,3 +6,4 @@ export * from './posts';
 export * from './comments';
 export * from './queryKeys';
 export * from './interest';
+export * from './search';

--- a/projects/common/src/apis/post.ts
+++ b/projects/common/src/apis/post.ts
@@ -1,3 +1,4 @@
+import { PostType } from 'src/constants';
 import { getAsync, postAsync, deleteAsync, ApiResult } from './apiUtils';
 
 export type StateType = 'all' | 'wait' | 'answered';
@@ -71,7 +72,7 @@ interface EditPostAsyncInput {
  */
 export const getPostDetailAsync = async (
   token: string,
-  postType: 'experiment' | 'request',
+  postType: PostType,
   postId: number,
 ): ApiResult<PostDetailType> => {
   const result = await getAsync<PostDetailType, any>(
@@ -92,7 +93,7 @@ export const getPostDetailAsync = async (
  * @param postId 게시물의 id값
  */
 export const getRelativePosts = async (
-  postType: 'request' | 'experiment',
+  postType: PostType,
   postId: number,
 ): ApiResult<RelativePostType[]> => {
   const result = await getAsync<RelativePostType[], any>(
@@ -114,7 +115,7 @@ export const getRelativePosts = async (
  */
 export const addPostAsync = async (
   token: string,
-  postType: 'experiment' | 'request',
+  postType: PostType,
   title: string,
   content: string,
   categories: string[],
@@ -164,7 +165,7 @@ export const getImgUploadURLAsync = async (
  */
 export const deletePostAsync = async (
   token: string,
-  postType: 'request' | 'experiment',
+  postType: PostType,
   postId: number,
 ): ApiResult<undefined> => {
   const result = await deleteAsync<undefined, any>(
@@ -192,7 +193,7 @@ export const deletePostAsync = async (
  */
 export const editPostAsync = async (
   token: string,
-  postType: 'experiment' | 'request',
+  postType: PostType,
   postId: number,
   title: string,
   content: string,

--- a/projects/common/src/apis/post.ts
+++ b/projects/common/src/apis/post.ts
@@ -1,4 +1,4 @@
-import { PostType } from 'src/constants';
+import { PostType } from '../constants';
 import { getAsync, postAsync, deleteAsync, ApiResult } from './apiUtils';
 
 export type StateType = 'all' | 'wait' | 'answered';

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -1,3 +1,4 @@
+import { PostType } from 'src/constants';
 import { getAsync, ApiResult } from './apiUtils';
 import { StateType, PostListType } from './post';
 
@@ -19,7 +20,7 @@ export type InfResultType<T> = {
  * @param state 의뢰에 대한 응답 상태에 따른 의뢰 게시물의 구분 (all | wait | answered)
  */
 export const getPostsAsync = async (
-  type: 'experiment' | 'request',
+  type: PostType,
   page: number,
   display: number,
   sort: SortType,

--- a/projects/common/src/apis/posts.ts
+++ b/projects/common/src/apis/posts.ts
@@ -1,4 +1,4 @@
-import { PostType } from 'src/constants';
+import { PostType } from '../constants';
 import { getAsync, ApiResult } from './apiUtils';
 import { StateType, PostListType } from './post';
 

--- a/projects/common/src/apis/search.ts
+++ b/projects/common/src/apis/search.ts
@@ -1,0 +1,43 @@
+import { PostType } from 'src/constants';
+import { getAsync, ApiResult } from './apiUtils';
+import { InfResultType, SortType } from './posts';
+import { PostListType } from './post';
+
+export type SearchType = 'tag' | 'query';
+
+/**
+ * 검색 종류, 게시물 종류, 키워드에 따른 검색 결과 반환하는 함수
+ * @param postType 게시물 종류 (experiment | request)
+ * @param searchType 검색 종류 (query | tag)
+ * @param keyword 검색어
+ * @param page page number
+ * @param display 게시물 개수
+ * @param sort 정렬 기준 (recent | popular)
+ *
+ */
+export const getSearchPostsAsync = async (
+  postType: PostType,
+  searchType: SearchType,
+  keyword: string,
+  page: number,
+  display: number,
+  sort: SortType,
+): ApiResult<InfResultType<PostListType[]>> => {
+  const response = await getAsync<PostListType[], any>(
+    `/search/${searchType}/${postType}`,
+    { params: { page, display, sort, tag: keyword, query: keyword } }, // TODO: 백엔드 url 수정 계획 (query, tag 부분을 통일)
+  );
+
+  if (response.isSuccess) {
+    return {
+      isSuccess: response.isSuccess,
+      result: {
+        list: response.result,
+        nextPage: page + 1,
+        isLast: response.result.length < display,
+      },
+    };
+  }
+
+  return response;
+};

--- a/projects/sasil-web/src/components/atoms/StyledLink/StyledLink.style.tsx
+++ b/projects/sasil-web/src/components/atoms/StyledLink/StyledLink.style.tsx
@@ -10,14 +10,14 @@ import { MEDIA_QUERIES } from '@/constants/styles';
 
 interface WrapProps {
   color?: string;
-  textStyleName: TextStyleName;
+  textStyleName?: TextStyleName;
 }
 
 export const Wrap = styled.a(({ color, textStyleName }: WrapProps) => ({
   color: color ?? COLORS.grayscale.black,
-  fontSize: TEXT_STYLES_PC[textStyleName].fontSize,
-  fontWeight: TEXT_STYLES_PC[textStyleName].fontWeight,
-  lineHeight: `${TEXT_STYLES_PC[textStyleName].lineHeight}px`,
+  fontSize: textStyleName && TEXT_STYLES_PC[textStyleName].fontSize,
+  fontWeight: textStyleName && TEXT_STYLES_PC[textStyleName].fontWeight,
+  lineHeight: textStyleName && `${TEXT_STYLES_PC[textStyleName].lineHeight}px`,
   textDecoration: 'none',
 
   ':visited': {
@@ -25,8 +25,9 @@ export const Wrap = styled.a(({ color, textStyleName }: WrapProps) => ({
   },
 
   [`@media ${MEDIA_QUERIES.mobile}`]: {
-    fontSize: TEXT_STYLES_MOBILE[textStyleName].fontSize,
-    fontWeight: TEXT_STYLES_MOBILE[textStyleName].fontWeight,
-    lineHeight: `${TEXT_STYLES_MOBILE[textStyleName].lineHeight}px`,
+    fontSize: textStyleName && TEXT_STYLES_MOBILE[textStyleName].fontSize,
+    fontWeight: textStyleName && TEXT_STYLES_MOBILE[textStyleName].fontWeight,
+    lineHeight:
+      textStyleName && `${TEXT_STYLES_MOBILE[textStyleName].lineHeight}px`,
   },
 }));

--- a/projects/sasil-web/src/components/atoms/StyledLink/StyledLink.tsx
+++ b/projects/sasil-web/src/components/atoms/StyledLink/StyledLink.tsx
@@ -2,12 +2,21 @@ import React from 'react';
 import Link from 'next/link';
 import { UrlObject } from 'url';
 
-import { StyledTextProps } from '@/components/atoms/StyledText';
+import { TextStyleName } from '@sasil/common';
 import * as styles from './StyledLink.style';
 
-export interface StyledLinkProps extends StyledTextProps {
+export interface StyledLinkProps {
   /** 클릭 시 이동할 url 주소 */
   url: string | UrlObject;
+  children: React.ReactNode;
+  /** 텍스트 색 (인자를 지정해주지 않을 시, 기본값은 black) */
+  color?: string;
+  /** 텍스트 스타일 종류로, TEXT_STYLE_NAME.* 로 지정된다. */
+  textStyleName?: TextStyleName;
+  /** 텍스트 overflow에 따른 ellipsis 처리 여부 */
+  ellipsis?: boolean;
+  /** 컴포넌트로 생성할 요소의 클래스명 */
+  className?: string;
 }
 
 const StyledLink = ({

--- a/projects/sasil-web/src/components/molelcules/CategoryBox/CategoryBox.tsx
+++ b/projects/sasil-web/src/components/molelcules/CategoryBox/CategoryBox.tsx
@@ -1,5 +1,6 @@
 import { COLORS, TEXT_STYLE_NAME } from '@sasil/common';
 import StyledLink from '@/components/atoms/StyledLink';
+import { URL_INFO } from '@/constants/urlInfo';
 import * as styles from './CategoryBox.style';
 
 export interface CategoryBoxProps {
@@ -29,7 +30,10 @@ const CategoryBox = ({
       className={className}
     >
       <StyledLink
-        url={{ query: { category: name } }} // TODO: 정책에 따른 변경 필요
+        url={{
+          pathname: URL_INFO.search,
+          query: { keyword: name, stype: 'tag' },
+        }}
         color={color}
         textStyleName={TEXT_STYLE_NAME.body2R}
         ellipsis

--- a/projects/sasil-web/src/components/molelcules/SearchBar/SearchBarWrapped.tsx
+++ b/projects/sasil-web/src/components/molelcules/SearchBar/SearchBarWrapped.tsx
@@ -22,10 +22,14 @@ const SearchBarWrapped = ({ className }: SearchBarWrappedProps) => {
         const keyword = value.replace('#', '');
         const searchType = value.indexOf('#') !== -1 ? 'tag' : 'query';
 
-        router.push({
-          pathname: `/search`,
-          query: { keyword, stype: searchType },
-        });
+        router.push(
+          {
+            pathname: `/search`,
+            query: { keyword, stype: searchType },
+          },
+          undefined,
+          { scroll: false },
+        );
       }
 
       setValue('');

--- a/projects/sasil-web/src/components/molelcules/SearchBar/SearchBarWrapped.tsx
+++ b/projects/sasil-web/src/components/molelcules/SearchBar/SearchBarWrapped.tsx
@@ -27,6 +27,8 @@ const SearchBarWrapped = ({ className }: SearchBarWrappedProps) => {
           query: { keyword, stype: searchType },
         });
       }
+
+      setValue('');
     },
     [router, value],
   );

--- a/projects/sasil-web/src/components/templates/MainTemplate/PageHeader.tsx
+++ b/projects/sasil-web/src/components/templates/MainTemplate/PageHeader.tsx
@@ -1,12 +1,14 @@
 import SasilLogoIcon from '@/assets/icons/SasilLogo.svg';
 import SearchIcon from '@/assets/icons/Search.svg';
 
+import { COLORS, TEXT_STYLE_NAME } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
 import ProfileImage from '@/components/atoms/ProfileImage';
 import StyledText from '@/components/atoms/StyledText';
-import { COLORS, TEXT_STYLE_NAME } from '@sasil/common';
+import StyledLink from '@/components/atoms/StyledLink';
 import * as styles from './PageHeader.style';
 
-// TODO: 검색 버튼 동작, ProfileImg 클릭 동작
+// TODO: ProfileImg 클릭 동작
 // TODO 로고 '사실;' 폰트 스타일이 mobile용 title로 변환되는지 확인
 const PageHeader = () => (
   <styles.StyledPageHeader>
@@ -26,7 +28,9 @@ const PageHeader = () => (
         </styles.MobileLogoWrapper>
         <styles.IconsWrapper>
           <ProfileImage size={32} />
-          <SearchIcon width="28" height="28" />
+          <StyledLink url={URL_INFO.search}>
+            <SearchIcon width="28" height="28" />
+          </StyledLink>
         </styles.IconsWrapper>
       </styles.TopWrapper>
     </styles.ContentWrapper>

--- a/projects/sasil-web/src/components/templates/ReqExpTemplate/PageHeader.tsx
+++ b/projects/sasil-web/src/components/templates/ReqExpTemplate/PageHeader.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 
 import { COLORS, TEXT_STYLE_NAME, CategoryType } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
 import RequestIcon from '@/assets/icons/Request.svg';
 import ExperimentIcon from '@/assets/icons/Experiment.svg';
 import SasilLogoIcon from '@/assets/icons/SasilLogo.svg';
@@ -37,7 +38,7 @@ const HEADER_ICON = {
   mobile: <SasilLogoIcon width="64" height="64" />,
 };
 
-// TODO: 검색 버튼 동작, ProfileImg 클릭 동작
+// TODO: ProfileImg 클릭 동작
 const PageHeader = ({ postType, sortType, categories }: PageHeaderProps) => {
   const router = useRouter();
   const goWrite = () => router.push(`/write/${postType}`);
@@ -56,7 +57,9 @@ const PageHeader = ({ postType, sortType, categories }: PageHeaderProps) => {
             {HEADER_ICON.mobile}
           </styles.MobileLogoWrapper>
           <styles.IconsWrapper>
-            <SearchIcon width="28" height="28" />
+            <StyledLink url={URL_INFO.search}>
+              <SearchIcon width="28" height="28" />
+            </StyledLink>
             <ProfileImage size={32} />
           </styles.IconsWrapper>
         </styles.TopWrapper>

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.stories.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.stories.tsx
@@ -10,34 +10,31 @@ export default {
 
 const Template: ComponentStory<typeof SearchTemplate> = ({
   keyword,
-  stype,
-  ptype,
-  expResPost,
-  reqResPost,
+  searchType,
+  postType,
+  posts,
+  postsRef,
 }: SearchTemplateProps) => (
   <SearchTemplate
     keyword={keyword}
-    stype={stype}
-    ptype={ptype}
-    expResPost={expResPost}
-    reqResPost={reqResPost}
+    searchType={searchType}
+    postType={postType}
+    posts={posts}
   />
 );
 
 export const TagSearchTemplate = Template.bind({});
 TagSearchTemplate.args = {
   keyword: '태그',
-  stype: 'tag',
-  ptype: 'experiment',
-  expResPost: expPosts,
-  reqResPost: reqPosts,
+  searchType: 'tag',
+  postType: 'experiment',
+  posts: expPosts,
 };
 
 export const wordSearchTemplate = Template.bind({});
 wordSearchTemplate.args = {
   keyword: '키워드',
-  stype: 'query',
-  ptype: 'request',
-  expResPost: expPosts,
-  reqResPost: reqPosts,
+  searchType: 'query',
+  postType: 'request',
+  posts: reqPosts,
 };

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
@@ -1,13 +1,18 @@
-import { COLORS, PostListType, TEXT_STYLE_NAME } from '@sasil/common';
+import React from 'react';
+
+import {
+  COLORS,
+  PostListType,
+  TEXT_STYLE_NAME,
+  PostType,
+  SearchType,
+} from '@sasil/common';
 import StyledText from '@/components/atoms/StyledText';
 import StyledLink from '@/components/atoms/StyledLink';
 import NavBar from '@/components/templates/NavBar';
 import PostsWrap from '@/components/templates/PostsWrap';
 import PageHeader from './PageHeader';
 import * as styles from './SearchTemplate.style';
-
-export type PostType = 'request' | 'experiment';
-export type SearchType = 'tag' | 'query';
 
 export interface SearchTemplateProps {
   /** 검색할 단어 혹은 해시태그 */
@@ -17,7 +22,8 @@ export interface SearchTemplateProps {
   /** 검색 결과로 보여줄 게시물 타입 */
   postType: PostType;
   /** 검색 결과 목록 */
-  posts: PostListType[];
+  posts?: PostListType[];
+  postsRef?: React.RefObject<HTMLDivElement>;
 }
 
 const SearchTemplate = ({
@@ -25,6 +31,7 @@ const SearchTemplate = ({
   searchType,
   postType,
   posts,
+  postsRef,
 }: SearchTemplateProps) => {
   const isTag = searchType === 'tag';
 
@@ -70,7 +77,7 @@ const SearchTemplate = ({
                   실험
                 </StyledLink>
               </styles.ToggleWrap>
-              <PostsWrap postType={postType} posts={posts} />
+              <PostsWrap postType={postType} posts={posts} ref={postsRef} />
             </styles.ContentWrap>
           ) : (
             <StyledText

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
@@ -13,27 +13,23 @@ export interface SearchTemplateProps {
   /** 검색할 단어 혹은 해시태그 */
   keyword?: string;
   /** 검색 타입 (키워드(query) or 태그) */
-  stype: SearchType;
+  searchType: SearchType;
   /** 검색 결과로 보여줄 게시물 타입 */
-  ptype?: PostType;
-  /** 검색 결과 실험 게시물 */
-  expResPost: PostListType[];
-  /** 검색 결과 의뢰 게시물 */
-  reqResPost: PostListType[];
+  postType: PostType;
+  /** 검색 결과 목록 */
+  posts: PostListType[];
 }
 
 const SearchTemplate = ({
   keyword,
-  stype,
-  ptype = 'request',
-  expResPost,
-  reqResPost,
+  searchType,
+  postType,
+  posts,
 }: SearchTemplateProps) => {
-  const isTag = stype === 'tag';
-  const postData = ptype === 'request' ? reqResPost : expResPost;
+  const isTag = searchType === 'tag';
 
   const [reqBtnColor, expBtnColor] =
-    ptype === 'request'
+    postType === 'request'
       ? [COLORS.grayscale.gray8, COLORS.grayscale.gray5]
       : [COLORS.grayscale.gray5, COLORS.grayscale.gray8];
 
@@ -56,7 +52,9 @@ const SearchTemplate = ({
               </StyledText>
               <styles.ToggleWrap>
                 <StyledLink
-                  url={{ query: { keyword, stype, ptype: 'request' } }}
+                  url={{
+                    query: { keyword, stype: searchType, ptype: 'request' },
+                  }}
                   textStyleName={TEXT_STYLE_NAME.subtitle1}
                   color={reqBtnColor}
                 >
@@ -64,7 +62,7 @@ const SearchTemplate = ({
                 </StyledLink>
                 <StyledLink
                   url={{
-                    query: { keyword, stype, ptype: 'experiment' },
+                    query: { keyword, stype: searchType, ptype: 'experiment' },
                   }}
                   textStyleName={TEXT_STYLE_NAME.subtitle1}
                   color={expBtnColor}
@@ -72,7 +70,7 @@ const SearchTemplate = ({
                   실험
                 </StyledLink>
               </styles.ToggleWrap>
-              <PostsWrap type={ptype} posts={postData} />
+              <PostsWrap postType={postType} posts={posts} />
             </styles.ContentWrap>
           ) : (
             <StyledText

--- a/projects/sasil-web/src/components/templates/SearchTemplate/index.ts
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/index.ts
@@ -1,5 +1,3 @@
 import SearchTemplate from './SearchTemplate';
 
-export type { PostType, SearchType } from './SearchTemplate';
-
 export default SearchTemplate;

--- a/projects/sasil-web/src/constants/urlInfo.ts
+++ b/projects/sasil-web/src/constants/urlInfo.ts
@@ -4,6 +4,7 @@ export const URL_INFO = {
   request: '/request',
   experiment: '/experiment',
   user: '/user',
+  search: '/search',
 } as const;
 
 export type UrlNameType = typeof URL_INFO[keyof typeof URL_INFO];

--- a/projects/sasil-web/src/pages/search.tsx
+++ b/projects/sasil-web/src/pages/search.tsx
@@ -1,22 +1,25 @@
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+
 import SearchTemplate, {
   PostType,
   SearchType,
 } from '@/components/templates/SearchTemplate';
-import { NextPage } from 'next';
-import { useRouter } from 'next/router';
-import { expPosts, reqPosts } from 'src/dummyData';
+import { expPosts } from 'src/dummyData';
 
 const Search: NextPage = () => {
   const router = useRouter();
   const { keyword, stype, ptype } = router.query;
 
+  const postType = (ptype || 'request') as PostType;
+  const searchType = (stype || 'query') as SearchType;
+
   return (
     <SearchTemplate
       keyword={keyword as string | undefined}
-      stype={stype as SearchType}
-      ptype={ptype as PostType}
-      expResPost={expPosts}
-      reqResPost={reqPosts}
+      searchType={searchType}
+      postType={postType}
+      posts={expPosts} // TODO
     />
   );
 };

--- a/projects/sasil-web/src/pages/search.tsx
+++ b/projects/sasil-web/src/pages/search.tsx
@@ -1,25 +1,75 @@
+import React, { useRef } from 'react';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
+import { useInfiniteQuery } from 'react-query';
 
-import SearchTemplate, {
+import {
+  getSearchPostsAsync,
   PostType,
   SearchType,
-} from '@/components/templates/SearchTemplate';
-import { expPosts } from 'src/dummyData';
+  SortType,
+} from '@sasil/common';
+import SearchTemplate from '@/components/templates/SearchTemplate';
+import useInifiniteScroll from '@/logics/hooks/useInfiniteScroll';
 
 const Search: NextPage = () => {
   const router = useRouter();
-  const { keyword, stype, ptype } = router.query;
+  const { keyword, stype, ptype, sort } = router.query;
 
   const postType = (ptype || 'request') as PostType;
   const searchType = (stype || 'query') as SearchType;
+  const sortType = (sort || 'popular') as SortType;
+  const display = 16;
+
+  const postsRef = useRef(null);
+
+  const { data, isFetching, hasNextPage, fetchNextPage } = useInfiniteQuery(
+    ['search', { postType, searchType, sortType, keyword }],
+    ({ pageParam = 1 }) => {
+      if (!router.isReady || !keyword) {
+        return undefined;
+      }
+
+      return getSearchPostsAsync(
+        postType,
+        searchType,
+        keyword as string,
+        pageParam,
+        display,
+        sortType,
+      );
+    },
+    {
+      getNextPageParam: (lastPage) => {
+        if (!lastPage || !lastPage.isSuccess || lastPage.result.isLast) {
+          return undefined;
+        }
+
+        return lastPage.result.nextPage;
+      },
+      staleTime: 300000, // TODO: 일단 cache-time의 default 값인 5분과 동일하게 맞춤
+    },
+  );
+
+  const getSearchPosts = async () => {
+    if (hasNextPage) {
+      await fetchNextPage();
+    }
+  };
+
+  useInifiniteScroll(postsRef, getSearchPosts);
+
+  const postsData = data?.pages
+    .map((res) => (res?.isSuccess ? res.result.list : []))
+    .flat();
 
   return (
     <SearchTemplate
       keyword={keyword as string | undefined}
+      postsRef={postsRef}
       searchType={searchType}
       postType={postType}
-      posts={expPosts} // TODO
+      posts={postsData}
     />
   );
 };

--- a/projects/sasil-web/src/pages/search.tsx
+++ b/projects/sasil-web/src/pages/search.tsx
@@ -10,7 +10,7 @@ import {
   SortType,
 } from '@sasil/common';
 import SearchTemplate from '@/components/templates/SearchTemplate';
-import useInifiniteScroll from '@/logics/hooks/useInfiniteScroll';
+import useInfiniteScroll from '@/logics/hooks/useInfiniteScroll';
 
 const Search: NextPage = () => {
   const router = useRouter();
@@ -57,7 +57,7 @@ const Search: NextPage = () => {
     }
   };
 
-  useInifiniteScroll(postsRef, getSearchPosts);
+  useInfiniteScroll(postsRef, getSearchPosts);
 
   const postsData = data?.pages
     .map((res) => (res?.isSuccess ? res.result.list : []))


### PR DESCRIPTION
## Issue
#87 

## Description
- 키워드/태그 검색을 위한 api를 common에 추가했습니다.
- 위 api를 이용하여 검색이 동작할 수 있도록 구현하였습니다. (infinite scroll)
  (확실히 재사용성 좋게 만들어놓으니깐 편하네여,,ㅎ)
- 카테고리 클릭 시, 태그 검색이 수행되도록 구현하였습니다.
- 모바일 ui에서 검색 아이콘 클릭 시, `/search` 페이지로 이동될 수 있도록 구현하였습니다.
- `StyledLink` 컴포넌트의 범용성?을 위해 `textStyleName` 속성이 `undefined`가 가능하도록 타입을 수정하였습니다.

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
