### PR TITLE
refactor : refactor search page UI

### DIFF
--- a/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.style.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.style.tsx
@@ -9,7 +9,7 @@ export const Container = styled.section({
   justifyContent: 'flex-start',
   flexWrap: 'wrap',
 
-  '.empty-notice': {
+  '.placeholder': {
     paddingLeft: '10px',
   },
 });

--- a/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.style.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.style.tsx
@@ -3,9 +3,13 @@ import styled from '@emotion/styled';
 export const Container = styled.section({
   maxWidth: '1400px',
   width: '100%',
-  minHeight: '100%',
+  minHeight: '200px',
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'flex-start',
   flexWrap: 'wrap',
+
+  '.empty-notice': {
+    paddingLeft: '10px',
+  },
 });

--- a/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
@@ -10,11 +10,11 @@ export interface PostsWrapProps {
   /** 게시물 리스트 */
   posts: PostListType[] | undefined;
   /** 보여줄 게시물이 없을 때 노출할 문구 */
-  emptyNotice?: string;
+  placeholder?: string;
 }
 
 const PostsWrap = forwardRef<HTMLDivElement, PostsWrapProps>(
-  ({ postType, posts, emptyNotice = '게시물이 없습니다' }, ref) => (
+  ({ postType, posts, placeholder = '게시물이 없습니다' }, ref) => (
     <styles.Container ref={ref}>
       {posts?.length ? (
         posts.map((post: PostListType) => (
@@ -31,9 +31,9 @@ const PostsWrap = forwardRef<HTMLDivElement, PostsWrapProps>(
         <StyledText
           textStyleName={TEXT_STYLE_NAME.subtitle2R}
           color={COLORS.grayscale.gray6}
-          className="empty-notice"
+          className="placeholder"
         >
-          {emptyNotice}
+          {placeholder}
         </StyledText>
       )}
     </styles.Container>

--- a/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
+++ b/projects/sasil-web/src/components/templates/PostsWrap/PostsWrap.tsx
@@ -1,27 +1,41 @@
 import React, { forwardRef } from 'react';
-import { useRouter } from 'next/router';
+import StyledText from '@/components/atoms/StyledText';
 import { Card } from '@/components/organisms/post';
-import { PostListType } from '@sasil/common';
+import { COLORS, PostListType, TEXT_STYLE_NAME } from '@sasil/common';
 import * as styles from './PostsWrap.style';
 
 export interface PostsWrapProps {
+  /** 게시물 타입  */
   postType: 'request' | 'experiment';
+  /** 게시물 리스트 */
   posts: PostListType[] | undefined;
+  /** 보여줄 게시물이 없을 때 노출할 문구 */
+  emptyNotice?: string;
 }
 
 const PostsWrap = forwardRef<HTMLDivElement, PostsWrapProps>(
-  ({ postType, posts }, ref) => (
+  ({ postType, posts, emptyNotice = '게시물이 없습니다' }, ref) => (
     <styles.Container ref={ref}>
-      {posts?.map((post: PostListType) => (
-        <Card
-          postUrl={`/post/${postType}/${post.id}`}
-          key={post.id}
-          title={post.title}
-          likeCount={post.likeCount}
-          thumbnail={post.thumbnail}
-          categories={post.categories}
-        />
-      ))}
+      {posts?.length ? (
+        posts.map((post: PostListType) => (
+          <Card
+            postUrl={`/post/${postType}/${post.id}`}
+            key={post.id}
+            title={post.title}
+            likeCount={post.likeCount}
+            thumbnail={post.thumbnail}
+            categories={post.categories}
+          />
+        ))
+      ) : (
+        <StyledText
+          textStyleName={TEXT_STYLE_NAME.subtitle2R}
+          color={COLORS.grayscale.gray6}
+          className="empty-notice"
+        >
+          {emptyNotice}
+        </StyledText>
+      )}
     </styles.Container>
   ),
 );

--- a/projects/sasil-web/src/components/templates/SearchTemplate/PageHeader.style.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/PageHeader.style.tsx
@@ -34,7 +34,7 @@ export const MobileHeader = styled.div({
 
 export const WebHeader = styled.div({
   width: '100%',
-  maxWidth: '1390px',
+  maxWidth: '1400px',
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',

--- a/projects/sasil-web/src/components/templates/SearchTemplate/PageHeader.style.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/PageHeader.style.tsx
@@ -8,7 +8,7 @@ export const HeaderWrap = styled.div({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'flex-end',
-  padding: '30px 30px 52px 30px',
+  padding: '30px 20px 52px',
 
   [`@media ${MEDIA_QUERIES.mobile}`]: {
     height: '114px',

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.style.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.style.tsx
@@ -45,9 +45,15 @@ export const PagesWrapper = styled.div({
 });
 
 export const ContentWrap = styled.div({
+  width: '100%',
+  maxWidth: '1400px',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
+
+  '.no-result-text': {
+    paddingLeft: '10px',
+  },
 });
 
 export const KeyWordWrap = styled.span(({ isTag }: { isTag: boolean }) => ({
@@ -58,14 +64,15 @@ export const KeyWordWrap = styled.span(({ isTag }: { isTag: boolean }) => ({
   backgroundColor: isTag ? COLORS.primary.alpha10 : 'transparent',
 }));
 
-export const ToggleWrap = styled.div({
-  display: 'flex',
+export const SwitchButtonArea = styled.div({
   width: '110px',
+  display: 'flex',
   justifyContent: 'space-between',
-  margin: '0px 0px 40px 10px',
+  marginBottom: '40px',
 
   [`@media ${MEDIA_QUERIES.mobile}`]: {
-    width: '85px',
-    marginBottom: '15px',
+    width: '100%',
+    justifyContent: 'center',
+    marginBottom: '20px',
   },
 });

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.style.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.style.tsx
@@ -26,7 +26,7 @@ export const Container = styled.div({
 
 export const PagesWrapper = styled.div({
   width: '100%',
-  padding: '42px 30px 80px',
+  padding: '55px 20px 80px',
   flex: 1,
   display: 'flex',
   justifyContent: 'center',
@@ -50,10 +50,6 @@ export const ContentWrap = styled.div({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-
-  '.no-result-text': {
-    paddingLeft: '10px',
-  },
 });
 
 export const KeyWordWrap = styled.span(({ isTag }: { isTag: boolean }) => ({

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
@@ -64,17 +64,12 @@ const SearchTemplate = ({
                   onRightMove={onRightMove}
                 />
               </styles.SwitchButtonArea>
-              {posts?.length ? (
-                <PostsWrap postType={postType} posts={posts} ref={postsRef} />
-              ) : (
-                <StyledText
-                  textStyleName={TEXT_STYLE_NAME.subtitle2R}
-                  color={COLORS.grayscale.gray6}
-                  className="no-result-text"
-                >
-                  검색 결과가 없습니다
-                </StyledText>
-              )}
+              <PostsWrap
+                postType={postType}
+                posts={posts}
+                ref={postsRef}
+                emptyNotice="검색 결과가 없습니다"
+              />
             </styles.ContentWrap>
           ) : (
             <StyledText

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
@@ -8,9 +8,9 @@ import {
   SearchType,
 } from '@sasil/common';
 import StyledText from '@/components/atoms/StyledText';
-import StyledLink from '@/components/atoms/StyledLink';
 import NavBar from '@/components/templates/NavBar';
 import PostsWrap from '@/components/templates/PostsWrap';
+import SwitchButton from '@/components/molelcules/SwitchButton';
 import PageHeader from './PageHeader';
 import * as styles from './SearchTemplate.style';
 
@@ -24,6 +24,8 @@ export interface SearchTemplateProps {
   /** 검색 결과 목록 */
   posts?: PostListType[];
   postsRef?: React.RefObject<HTMLDivElement>;
+  onLeftMove?: () => void;
+  onRightMove?: () => void;
 }
 
 const SearchTemplate = ({
@@ -32,14 +34,10 @@ const SearchTemplate = ({
   postType,
   posts,
   postsRef,
+  onLeftMove,
+  onRightMove,
 }: SearchTemplateProps) => {
   const isTag = searchType === 'tag';
-
-  const [reqBtnColor, expBtnColor] =
-    postType === 'request'
-      ? [COLORS.grayscale.gray8, COLORS.grayscale.gray5]
-      : [COLORS.grayscale.gray5, COLORS.grayscale.gray8];
-
   return (
     <NavBar focusType="main">
       <styles.Container>
@@ -57,27 +55,26 @@ const SearchTemplate = ({
                 </styles.KeyWordWrap>
                 검색결과
               </StyledText>
-              <styles.ToggleWrap>
-                <StyledLink
-                  url={{
-                    query: { keyword, stype: searchType, ptype: 'request' },
-                  }}
-                  textStyleName={TEXT_STYLE_NAME.subtitle1}
-                  color={reqBtnColor}
+              <styles.SwitchButtonArea>
+                <SwitchButton
+                  leftLabel="의뢰"
+                  rightLabel="실험"
+                  initRight={postType === 'experiment'}
+                  onLeftMove={onLeftMove}
+                  onRightMove={onRightMove}
+                />
+              </styles.SwitchButtonArea>
+              {posts?.length ? (
+                <PostsWrap postType={postType} posts={posts} ref={postsRef} />
+              ) : (
+                <StyledText
+                  textStyleName={TEXT_STYLE_NAME.subtitle2R}
+                  color={COLORS.grayscale.gray6}
+                  className="no-result-text"
                 >
-                  의뢰
-                </StyledLink>
-                <StyledLink
-                  url={{
-                    query: { keyword, stype: searchType, ptype: 'experiment' },
-                  }}
-                  textStyleName={TEXT_STYLE_NAME.subtitle1}
-                  color={expBtnColor}
-                >
-                  실험
-                </StyledLink>
-              </styles.ToggleWrap>
-              <PostsWrap postType={postType} posts={posts} ref={postsRef} />
+                  검색 결과가 없습니다
+                </StyledText>
+              )}
             </styles.ContentWrap>
           ) : (
             <StyledText

--- a/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/SearchTemplate/SearchTemplate.tsx
@@ -68,7 +68,7 @@ const SearchTemplate = ({
                 postType={postType}
                 posts={posts}
                 ref={postsRef}
-                emptyNotice="검색 결과가 없습니다"
+                placeholder="검색 결과가 없습니다"
               />
             </styles.ContentWrap>
           ) : (

--- a/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
@@ -39,7 +39,7 @@ const UserPageTemplate = ({
           postType={postType}
           posts={posts}
           ref={postsRef}
-          emptyNotice="게시물이 없습니다"
+          placeholder="게시물이 없습니다"
         />
       </styles.BodyWrapper>
     </styles.Container>

--- a/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
@@ -35,7 +35,12 @@ const UserPageTemplate = ({
             onRightMove={onRightMove}
           />
         </styles.SwitchButtonArea>
-        <PostsWrap postType={postType} posts={posts} ref={postsRef} />
+        <PostsWrap
+          postType={postType}
+          posts={posts}
+          ref={postsRef}
+          emptyNotice="게시물이 없습니다"
+        />
       </styles.BodyWrapper>
     </styles.Container>
   </NavBar>

--- a/projects/sasil-web/src/pages/search.tsx
+++ b/projects/sasil-web/src/pages/search.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { useInfiniteQuery } from 'react-query';
@@ -57,6 +57,36 @@ const Search: NextPage = () => {
     }
   };
 
+  const onLeftMove = useCallback(() => {
+    router.push(
+      {
+        pathname: `/search`,
+        query: {
+          keyword,
+          stype: searchType,
+          ptype: 'request',
+        },
+      },
+      undefined,
+      { scroll: false },
+    );
+  }, [router, searchType, keyword]);
+
+  const onRightMove = useCallback(() => {
+    router.push(
+      {
+        pathname: `/search`,
+        query: {
+          keyword,
+          stype: searchType,
+          ptype: 'experiment',
+        },
+      },
+      undefined,
+      { scroll: false },
+    );
+  }, [router, searchType, keyword]);
+
   useInfiniteScroll(postsRef, getSearchPosts);
 
   const postsData = data?.pages
@@ -70,6 +100,8 @@ const Search: NextPage = () => {
       searchType={searchType}
       postType={postType}
       posts={postsData}
+      onLeftMove={onLeftMove}
+      onRightMove={onRightMove}
     />
   );
 };


### PR DESCRIPTION
## Issue
#90 
## Description
검색 결과 페이지 UI 를 수정하였습니다..
- 토글 버튼을 이강현씨가 만들어놓으신 `SwitchButton` 으로 변경
- 검색 결과가 없을 경우 '검색 결과 없습니다' 문구 추가
- 게시물 리스트 중앙 정렬 -> 왼쪽 정렬 으로 변경
- `PostsWrap` prop에 emptyNotice 를 추가하여, 게시물 데이터가 없을 경우 화면에 노출될 문구를 지정

앞으로 더 꼼꼼하게 확인하고 개발하는 개발자가 되겠습니다..

## Check List

- [X] PR 제목을 commit 규칙에 맞게 작성
- [X] WIP를 붙여야 하는 상황인지 확인
- [X] label 설정
- [X] 작업한 사람 모두를 Assign
- [X] Code Review 요청
