### PR TITLE
feat: activate buttons related to user page

### DIFF
--- a/projects/sasil-web/src/components/molelcules/WriterInfo/WriterInfo.style.tsx
+++ b/projects/sasil-web/src/components/molelcules/WriterInfo/WriterInfo.style.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 export const WriterWrap = styled.div({
   display: 'flex',
   alignItems: 'center',
+  cursor: 'pointer',
 
   '.writer-info': {
     marginLeft: 6,

--- a/projects/sasil-web/src/components/molelcules/WriterInfo/WriterInfo.tsx
+++ b/projects/sasil-web/src/components/molelcules/WriterInfo/WriterInfo.tsx
@@ -1,5 +1,5 @@
-import ProfileImage from '@/components/atoms/ProfileImage';
-import StyledText from '@/components/atoms/StyledText';
+import { useRouter } from 'next/router';
+
 import {
   COLORS,
   TextStyleName,
@@ -7,6 +7,10 @@ import {
   WriterType,
   DELETED_USER_NICKNAME,
 } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
+import ProfileImage from '@/components/atoms/ProfileImage';
+import StyledText from '@/components/atoms/StyledText';
+import { useCallback } from 'react';
 import * as styles from './WriterInfo.style';
 
 const formatDate = (date: string) => {
@@ -42,26 +46,34 @@ const WriterInfo = ({
   textColor,
   profileSize,
   writeDate,
-}: WriterInfoProps) => (
-  <styles.WriterWrap>
-    <ProfileImage src={writerObj?.profileImg} size={profileSize} />
-    <StyledText
-      color={textColor}
-      textStyleName={textStyleName}
-      className="writer-info"
-    >
-      {writerObj?.nickname ?? DELETED_USER_NICKNAME}
-    </StyledText>
-    {writeDate && (
+}: WriterInfoProps) => {
+  const router = useRouter();
+
+  const onClick = useCallback(() => {
+    router.push(`${URL_INFO.user}/${writerObj?.id}`);
+  }, [router, writerObj?.id]);
+
+  return (
+    <styles.WriterWrap onClick={onClick}>
+      <ProfileImage src={writerObj?.profileImg} size={profileSize} />
       <StyledText
-        color={COLORS.grayscale.gray5}
-        textStyleName={TEXT_STYLE_NAME.body3}
-        className="create-date"
+        color={textColor}
+        textStyleName={textStyleName}
+        className="writer-info"
       >
-        {formatDate(writeDate)}
+        {writerObj?.nickname ?? DELETED_USER_NICKNAME}
       </StyledText>
-    )}
-  </styles.WriterWrap>
-);
+      {writeDate && (
+        <StyledText
+          color={COLORS.grayscale.gray5}
+          textStyleName={TEXT_STYLE_NAME.body3}
+          className="create-date"
+        >
+          {formatDate(writeDate)}
+        </StyledText>
+      )}
+    </styles.WriterWrap>
+  );
+};
 
 export default WriterInfo;

--- a/projects/sasil-web/src/components/organisms/Navigation/Navigation.tsx
+++ b/projects/sasil-web/src/components/organisms/Navigation/Navigation.tsx
@@ -4,14 +4,14 @@ import NavItem from './NavItem';
 import * as styles from './Navigation.style';
 
 export interface NavigationProps {
-  focusType: NavItemKey;
+  focusType?: NavItemKey;
+  userId?: number | null;
 }
 
-// TODO: focusType을 Template 단에서 props drilling으로 받아오는데, Navigation에서 router.pathname 이용해서 사용하는 방식은 어떤지?
 /**
  * 페이지 이동을 위한 네비게이션을 생성하는 컴포넌트 (반응형)
  */
-const Navigation = ({ focusType }: NavigationProps) => {
+const Navigation = ({ focusType, userId }: NavigationProps) => {
   const navList = Object.keys(NAV_INFO) as [NavItemKey];
 
   return (
@@ -19,11 +19,16 @@ const Navigation = ({ focusType }: NavigationProps) => {
       {navList.map((navType) => {
         const isFocused = focusType === navType;
 
+        const myPageURL = userId
+          ? `${URL_INFO[navType]}/${userId}`
+          : URL_INFO.login;
+        const targetURL = navType === 'user' ? myPageURL : URL_INFO[navType];
+
         return (
           <NavItem
             type={navType}
             name={NAV_INFO[navType].name_kr}
-            targetURL={URL_INFO[navType]}
+            targetURL={targetURL}
             isFocused={isFocused}
             key={navType}
           />

--- a/projects/sasil-web/src/components/organisms/PostEditor/PostEditorWrapped.tsx
+++ b/projects/sasil-web/src/components/organisms/PostEditor/PostEditorWrapped.tsx
@@ -1,10 +1,12 @@
 import React, { useRef, useState } from 'react';
-import { addPostAsync, getImgUploadURLAsync } from '@sasil/common';
-import { postAsync } from '@sasil/common/dist/apis/apiUtils';
 import { useRouter } from 'next/router';
 import { Editor as EditorType } from '@toast-ui/react-editor';
-import { HookCallback } from '@/components/molelcules/Editor/Editor';
 import { useAtom } from 'jotai';
+
+import { addPostAsync, getImgUploadURLAsync } from '@sasil/common';
+import { postAsync } from '@sasil/common/dist/apis/apiUtils';
+import { URL_INFO } from '@/constants/urlInfo';
+import { HookCallback } from '@/components/molelcules/Editor/Editor';
 import { getUserInfoAtom } from '@/logics/store/actions';
 import PostEditor from './PostEditor';
 
@@ -97,7 +99,7 @@ const PostEditorWrapped = ({ type }: PostEditorWrappedProps) => {
 
     if (mdText) {
       if (!userInfo?.token) {
-        router.push('/login');
+        router.push(URL_INFO.login);
         return;
       }
 

--- a/projects/sasil-web/src/components/organisms/PostWriteNav/PostWriteNav.tsx
+++ b/projects/sasil-web/src/components/organisms/PostWriteNav/PostWriteNav.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { COLORS } from '@sasil/common';
-import { getUserInfoAtom } from '@/logics/store/actions';
 import { useAtom } from 'jotai';
-import StyledText from '@/components/atoms/StyledText';
 
+import { COLORS } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
+import { getUserInfoAtom } from '@/logics/store/actions';
 import Plus from '@/assets/icons/Plus.svg';
 import Request from '@/assets/icons/Request.svg';
 import Experiment from '@/assets/icons/Experiment.svg';
+import StyledText from '@/components/atoms/StyledText';
 import * as styles from './PostWriteNav.style';
 
 interface ListItemProps {
@@ -48,13 +49,15 @@ const PostWriteNav = () => {
           <ListItem
             type="request"
             onClick={() =>
-              router.push(userInfo?.token ? '/write/request' : '/login')
+              router.push(userInfo?.token ? '/write/request' : URL_INFO.login)
             }
           />
           <ListItem
             type="experiment"
             onClick={() =>
-              router.push(userInfo?.token ? '/write/experiment' : '/login')
+              router.push(
+                userInfo?.token ? '/write/experiment' : URL_INFO.login,
+              )
             }
           />
         </styles.ListWrap>

--- a/projects/sasil-web/src/components/templates/CommentsArea/CommentsAreaWrapped.tsx
+++ b/projects/sasil-web/src/components/templates/CommentsArea/CommentsAreaWrapped.tsx
@@ -8,6 +8,7 @@ import {
   addCommentAsync,
   deleteCommentAsync,
 } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
 import useInifiniteScroll from '@/logics/hooks/useInfiniteScroll';
 import { getUserInfoAtom } from '@/logics/store/actions';
 import CommentsArea from './CommentsArea';
@@ -61,7 +62,7 @@ const CommentsAreaWrapped = () => {
   const addComment = useCallback(async () => {
     if (commentValue.length > 0) {
       if (!userInfo?.token) {
-        router.push('/login');
+        router.push(URL_INFO.login);
         return;
       }
 
@@ -114,7 +115,7 @@ const CommentsAreaWrapped = () => {
     }));
 
     if (!userInfo?.token) {
-      router.push('/login');
+      router.push(URL_INFO.login);
       return;
     }
 

--- a/projects/sasil-web/src/components/templates/NavBar/NavBar.tsx
+++ b/projects/sasil-web/src/components/templates/NavBar/NavBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { useAtom } from 'jotai';
 
 import { NavItemKey } from '@sasil/common';
+import { getUserInfoAtom } from '@/logics/store/actions';
 import Navigation from '@/components/organisms/Navigation';
 import ProfileImage from '@/components/atoms/ProfileImage';
 import { SearchBarWrapped } from '@/components/molelcules/SearchBar';
@@ -8,25 +10,35 @@ import * as styles from './NavBar.style';
 
 export interface NavBarProps {
   children: React.ReactNode;
-  focusType: NavItemKey;
+  focusType?: NavItemKey;
   className?: string;
 }
 
-// TODO: 프로필사진 전역 상태에서 가져오기
 /**
  * 메뉴바를 생성하는 컴포넌트 (반응형)
  */
-const NavBar = ({ children, focusType, className }: NavBarProps) => (
-  <>
-    <styles.StyledNavBar className={className}>
-      <SearchBarWrapped className="menu_search-bar" />
-      <styles.SideMenu>
-        <Navigation focusType={focusType} />
-        <ProfileImage size={34} className="menu_profile-img" />
-      </styles.SideMenu>
-    </styles.StyledNavBar>
-    {children}
-  </>
-);
+const NavBar = ({ children, focusType, className }: NavBarProps) => {
+  const [userInfo] = useAtom(getUserInfoAtom);
+
+  const profileImgURL = userInfo?.profileImg;
+  const userId = userInfo?.id;
+
+  return (
+    <>
+      <styles.StyledNavBar className={className}>
+        <SearchBarWrapped className="menu_search-bar" />
+        <styles.SideMenu>
+          <Navigation focusType={focusType} userId={userId} />
+          <ProfileImage
+            size={34}
+            className="menu_profile-img"
+            src={profileImgURL}
+          />
+        </styles.SideMenu>
+      </styles.StyledNavBar>
+      {children}
+    </>
+  );
+};
 
 export default NavBar;

--- a/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.stories.tsx
+++ b/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.stories.tsx
@@ -14,6 +14,7 @@ const Template: ComponentStory<typeof UserPageTemplate> = ({
   tabType,
   postType,
   posts,
+  isMyPage,
   postsRef,
 }: UserPageTemplateProps) => (
   <UserPageTemplate
@@ -22,6 +23,7 @@ const Template: ComponentStory<typeof UserPageTemplate> = ({
     postType={postType}
     posts={posts}
     postsRef={postsRef}
+    isMyPage={isMyPage}
   />
 );
 
@@ -31,4 +33,5 @@ Default.args = {
   tabType: 'userPosts',
   postType: 'experiment',
   posts: expPosts,
+  isMyPage: true,
 };

--- a/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.style.tsx
+++ b/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.style.tsx
@@ -24,7 +24,7 @@ export const BodyWrapper = styled.div({
   alignItems: 'center',
   minHeight: '100%',
   width: '100%',
-  padding: '57px 0',
+  padding: '55px 20px',
   backgroundColor: COLORS.background,
 
   [`@media ${MEDIA_QUERIES.mobile}`]: {

--- a/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
+++ b/projects/sasil-web/src/components/templates/UserPageTemplate/UserPageTemplate.tsx
@@ -8,11 +8,11 @@ import * as styles from './UserPageTemplate.style';
 
 export interface UserPageTemplateProps extends PostsWrapProps, PageHeaderProps {
   postsRef?: React.RefObject<HTMLDivElement>;
+  isMyPage: boolean;
   onLeftMove?: () => void;
   onRightMove?: () => void;
 }
 
-// TODO: PostType을 선택하는 컴포넌트 구현
 const UserPageTemplate = ({
   userInfo,
   tabType,
@@ -21,8 +21,9 @@ const UserPageTemplate = ({
   postsRef,
   onLeftMove,
   onRightMove,
+  isMyPage,
 }: UserPageTemplateProps) => (
-  <NavBar focusType="user">
+  <NavBar focusType={isMyPage ? 'user' : undefined}>
     <styles.Container>
       <PageHeader tabType={tabType} userInfo={userInfo} />
       <styles.BodyWrapper>

--- a/projects/sasil-web/src/constants/urlInfo.ts
+++ b/projects/sasil-web/src/constants/urlInfo.ts
@@ -5,6 +5,7 @@ export const URL_INFO = {
   experiment: '/experiment',
   user: '/user',
   search: '/search',
+  login: '/login',
 } as const;
 
 export type UrlNameType = typeof URL_INFO[keyof typeof URL_INFO];

--- a/projects/sasil-web/src/pages/post/[type]/[pid].tsx
+++ b/projects/sasil-web/src/pages/post/[type]/[pid].tsx
@@ -15,6 +15,7 @@ import {
   PostDetailType,
   RelativePostType,
 } from '@sasil/common';
+import { URL_INFO } from '@/constants/urlInfo';
 import { getUserInfoAtom } from '@/logics/store/actions';
 
 // Toast Viewer를 사용하기 위한 ssr 해제
@@ -105,7 +106,7 @@ const PostDetail: NextPage = () => {
 
   const handleLike = useCallback(async () => {
     if (!userInfo?.token) {
-      router.push('/login');
+      router.push(URL_INFO.login);
       return;
     }
 
@@ -124,7 +125,7 @@ const PostDetail: NextPage = () => {
 
   const handleBookmark = useCallback(async () => {
     if (!userInfo?.token) {
-      router.push('/login');
+      router.push(URL_INFO.login);
       return;
     }
     const result = bookmarkInfo.isBookmark
@@ -151,7 +152,7 @@ const PostDetail: NextPage = () => {
     }
 
     if (!userInfo?.token) {
-      router.push('/login');
+      router.push(URL_INFO.login);
       return;
     }
 

--- a/projects/sasil-web/src/pages/user/[uid].tsx
+++ b/projects/sasil-web/src/pages/user/[uid].tsx
@@ -111,6 +111,8 @@ const UserPage: NextPage = () => {
     .map((res) => (res && res.isSuccess ? res.result.list : []))
     .flat();
 
+  const isMyPage = myInfo?.id === userInfo.id;
+
   return (
     <UserPageTemplate
       userInfo={userInfo}
@@ -120,6 +122,7 @@ const UserPage: NextPage = () => {
       postsRef={postsRef}
       onLeftMove={onLeftMove}
       onRightMove={onRightMove}
+      isMyPage={isMyPage}
     />
   );
 };


### PR DESCRIPTION
## Issue
#93

## Description
유저 페이지 이동을 위한 버튼 활성화 작업을 진행하였습니다.
마이페이지 버튼 클릭 시, 전역상태에 존재하는 내 정보를 가져와 id값을 이용해 이동하며 
작성자 유저프로필 클릭 시 , 유저 id 값을 이용해 이동합니다.

작업하는 과정에서 로그인 URL을 constants 디렉토리에 추가하여 작업했습니다.
그런데 다른 URL들이 좀 난잡하게 사용되던데, 나중에 URL 관련 작업에 대해서 이야기해보면 좋을 것 같습니다!

## Check List
- [x] PR 제목을 commit 규칙에 맞게 작성
- [x] WIP를 붙여야 하는 상황인지 확인
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
